### PR TITLE
chore: use github-action type for catalog info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,6 @@ metadata:
   description: |
     GitHub action to setup and use Grizzly 
 spec:
-  type: tool
+  type: github-action
   owner: group:default/platform-monitoring
   lifecycle: production


### PR DESCRIPTION
In our internal catalog we now have a dedicated component type called "github-action" 🙂